### PR TITLE
Initialize crontab

### DIFF
--- a/sd/test/crontabs_root
+++ b/sd/test/crontabs_root
@@ -1,0 +1,23 @@
+# cat /var/spool/cron/crontabs/root
+# Edit this file to introduce tasks to be run by cron.
+#
+# Each task to run has to be defined through a single line
+# indicating with different fields when the task will be run
+# and what command to run for the task
+#
+# To define the time you can provide concrete values for
+# minute (m), hour (h), day of month (dom), month (mon),
+# and day of week (dow) or use '*' in these fields (for 'any').#
+# Notice that tasks will be started based on the cron's system
+# daemon's notion of time and timezones.
+#
+# Output of the crontab jobs (including errors) is sent through
+# email to the user the crontab file belongs to (unless redirected).
+#
+# For example, you can run a backup of all your user accounts
+# at 5 a.m every week with:
+# 0 5 * * 1 tar -zcf /var/backups/home.tgz /home/
+#
+# For more information see the manual pages of crontab(5) and cron(8)
+#
+# m h  dom mon dow    command

--- a/sd/test/equip_test.sh
+++ b/sd/test/equip_test.sh
@@ -459,6 +459,9 @@ crontab_folder="/var/spool/cron/crontabs"
 if [ ! -r "$crontab_folder" ]; then
     mkdir -p "$crontab_folder"
 fi
+if [ ! -r "/var/spool/cron/crontabs/root" ]; then
+    cp /home/hd1/test/crontabs_root /var/spool/cron/crontabs/root
+fi
 # Start crond daemon
 /usr/sbin/crond -b
 


### PR DESCRIPTION
When booting up, crond daemon is started up and folder
/var/spool/cron/crontabs is created. This just ensure crond starts
without error.
This commit make the default crontab file for root user under above
folder which is modified by the "contab -e" command.